### PR TITLE
SimplePagerTitleView now returns correct ContentLeft and ContentRight…

### DIFF
--- a/magicindicator/src/main/java/net/lucode/hackware/magicindicator/buildins/commonnavigator/titles/SimplePagerTitleView.java
+++ b/magicindicator/src/main/java/net/lucode/hackware/magicindicator/buildins/commonnavigator/titles/SimplePagerTitleView.java
@@ -54,7 +54,16 @@ public class SimplePagerTitleView extends TextView implements IMeasurablePagerTi
     @Override
     public int getContentLeft() {
         Rect bound = new Rect();
-        getPaint().getTextBounds(getText().toString(), 0, getText().length(), bound);
+        String longestString = "";
+        if (getText().toString().contains("\n")) {
+            String[] brokenStrings = getText().toString().split("\\n");
+            for (String each : brokenStrings) {
+                if (each.length() > longestString.length()) longestString = each;
+            }
+        } else {
+            longestString = getText().toString();
+        }
+        getPaint().getTextBounds(longestString, 0, longestString.length(), bound);
         int contentWidth = bound.width();
         return getLeft() + getWidth() / 2 - contentWidth / 2;
     }
@@ -69,7 +78,16 @@ public class SimplePagerTitleView extends TextView implements IMeasurablePagerTi
     @Override
     public int getContentRight() {
         Rect bound = new Rect();
-        getPaint().getTextBounds(getText().toString(), 0, getText().length(), bound);
+        String longestString = "";
+        if (getText().toString().contains("\n")) {
+            String[] brokenStrings = getText().toString().split("\\n");
+            for (String each : brokenStrings) {
+                if (each.length() > longestString.length()) longestString = each;
+            }
+        } else {
+            longestString = getText().toString();
+        }
+        getPaint().getTextBounds(longestString, 0, longestString.length(), bound);
         int contentWidth = bound.width();
         return getLeft() + getWidth() / 2 + contentWidth / 2;
     }


### PR DESCRIPTION
… if text has a linebreak

fixes #76 

Effect:
![_20171003_170536](https://user-images.githubusercontent.com/28033467/31117659-38c687da-a85d-11e7-81f3-201b38dbe079.JPG)
