### PR TITLE
Fix the measure bug

### DIFF
--- a/app/src/main/java/net/lucode/hackware/magicindicatordemo/ext/navigator/ScaleCircleNavigator.java
+++ b/app/src/main/java/net/lucode/hackware/magicindicatordemo/ext/navigator/ScaleCircleNavigator.java
@@ -101,7 +101,11 @@ public class ScaleCircleNavigator extends View implements IPagerNavigator, Navig
                 break;
             case MeasureSpec.AT_MOST:
             case MeasureSpec.UNSPECIFIED:
-                result = (mCircleCount - 1) * mMinRadius * 2 + mMaxRadius * 2 + (mCircleCount - 1) * mCircleSpacing + getPaddingLeft() + getPaddingRight();
+                if (mCircleCount <= 0) {
+                    result = getPaddingLeft() + getPaddingRight();
+                } else {
+                    result = (mCircleCount - 1) * mMinRadius * 2 + mMaxRadius * 2 + (mCircleCount - 1) * mCircleSpacing + getPaddingLeft() + getPaddingRight();
+                }
                 break;
             default:
                 break;
@@ -209,7 +213,7 @@ public class ScaleCircleNavigator extends View implements IPagerNavigator, Navig
     @Override
     public void notifyDataSetChanged() {
         prepareCirclePoints();
-        invalidate();
+        requestLayout();
     }
 
     @Override


### PR DESCRIPTION
ScaleCircleNavigator 未进行边界条件判断，会出现没有数据的情况，这个时候会导致，布局测量出错，会撑开父布局，造成布局紊乱。