### PR TITLE
更正 README 中 Gradle 引用依赖方式为 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Simple steps, you can integrate **MagicIndicator**:
 2. import module **magicindicator** and add dependency:
 
   ```groovy
-  compile project(':magicindicator')
+  implementation project(':magicindicator')
   ```
   
   **or**
@@ -31,7 +31,7 @@ Simple steps, you can integrate **MagicIndicator**:
   
   dependencies {
       ...
-      compile 'com.github.hackware1993:MagicIndicator:1.5.0'
+      implementation 'com.github.hackware1993:MagicIndicator:1.6.0'
   }
   ```
   


### PR DESCRIPTION
更新了使用介绍中添加依赖关键词为 implementation